### PR TITLE
Fix broken Homepage link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Three layers:
 - `wiki/` — LLM-generated synthesis pages organised by type (papers, concepts, methods, entities, comparisons, connections, mindmaps).
 - `CLAUDE.md` + `.claude/skills/` — schema and operation protocols that drive how the wiki is built.
 
-See the [site Home page](https://) for the full layer-architecture explanation and wiki-vs-RAG comparison.
+See the [site Home page](https://lydieberget.github.io/second-brain/) for the full layer-architecture explanation and wiki-vs-RAG comparison.
 
 ## Local development
 


### PR DESCRIPTION
## Summary
- Replace placeholder `https://` with the live GitHub Pages URL `https://lydieberget.github.io/second-brain/`

Closes #3

## Test plan
- [x] Confirmed Pages deploy is live via `gh api repos/.../pages` (status: built)
- [ ] Click the link in the rendered README on GitHub and verify it loads the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)