### PR TITLE
Add MathJax render preflight to wiki-deploy

### DIFF
--- a/.claude/skills/wiki-deploy/SKILL.md
+++ b/.claude/skills/wiki-deploy/SKILL.md
@@ -24,7 +24,15 @@ python scripts/sync_wiki_to_mkdocs.py
 
 The script copies everything in `wiki/` to `site/docs/` and rewrites `[[wikilinks]]` into MkDocs-compatible relative links. Preserves `site/docs/javascripts/` (MathJax config) across runs.
 
-### 2. Build statically
+### 2. Preflight: MathJax sanity check
+
+```bash
+python scripts/preflight_mathjax.py
+```
+
+Validates the four regression-prone conditions that broke math rendering on 2026-04-16 / -17 / -18: mathjax-config.js load order in `mkdocs.yml`, delimiter set in the config (no bare `$`), `document$.subscribe` guard for Material's instant-nav observable, and cache clears on SPA page swaps. Non-zero exit must block the deploy — do not proceed to the build step until it passes. If it fails, the error code (M1..M4, C1..C6) identifies the specific regression; see `scripts/preflight_mathjax.py` docstring for the full list.
+
+### 3. Build statically
 
 ```bash
 cd site && mkdocs build --strict
@@ -34,7 +42,7 @@ cd site && mkdocs build --strict
 
 Output lands in `site/site/`. Expected: `index.html`, 404 page, `assets/`, `javascripts/`, one directory per section (`papers/`, `concepts/`, `methods/`, etc.).
 
-### 3. Local preview (optional but recommended)
+### 4. Local preview (optional but recommended)
 
 ```bash
 cd site && mkdocs serve
@@ -69,7 +77,7 @@ Current public URL: the `https://<owner>.github.io/second-brain/` after GitHub P
 
 ## Troubleshooting
 
-- **Equations render as raw LaTeX**: check that `site/docs/javascripts/mathjax-config.js` loads BEFORE MathJax CDN in `mkdocs.yml` `extra_javascript`, and that it uses only `\\(...\\)` / `\\[...\\]` delimiters (no `$`/`$$` — those conflict with arithmatex `generic: true`).
+- **Equations render as raw LaTeX**: run `python scripts/preflight_mathjax.py` — it covers the four recurring causes (load order in `mkdocs.yml`, bare `$` delimiters conflicting with arithmatex `generic: true`, unguarded `document$.subscribe`, missing SPA-nav cache clears). Failure codes map 1:1 to each cause.
 - **Mermaid diagrams don't render**: check `mermaid2` plugin is listed in `mkdocs.yml` plugins and Mermaid version ≥ 10.x (for `mindmap` type support).
 - **Click on diagram node does nothing**: the `mermaid2` plugin config must include `arguments: { securityLevel: loose }`. Mermaid defaults to `strict` which silently blocks `click` directives.
 - **Dev server shows old content after sync**: kill and restart `mkdocs serve` — it occasionally caches. `netstat -ano | grep :8000` then `taskkill //F //PID <pid>`.

--- a/scripts/preflight_mathjax.py
+++ b/scripts/preflight_mathjax.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Preflight check for MathJax rendering on the MkDocs site.
+
+Validates the four regression-prone conditions that broke math rendering three
+times in April 2026 (see wiki/log.md). Invoked by the wiki-deploy skill before
+`mkdocs build`. Exits non-zero with a specific failure code if any check fails.
+
+Checks:
+    M — mkdocs.yml
+        M1: `extra_javascript` block is present.
+        M2: `mathjax-config.js` is listed in `extra_javascript`.
+        M3: MathJax CDN is listed in `extra_javascript`.
+        M4: config script loads BEFORE the CDN (else window.MathJax is ignored).
+    C — site/docs/javascripts/mathjax-config.js
+        C1: tex.inlineMath and tex.displayMath delimiter arrays exist.
+        C2: neither array contains a bare $-delimiter (conflicts with arithmatex).
+        C3: document$.subscribe is called (required for SPA-nav re-typeset).
+        C4: document$ access is guarded (typeof check + setTimeout retry).
+        C5: MathJax.typesetClear is called on navigation.
+        C6: MathJax.startup.output.clearCache is called on navigation.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print(
+        "[preflight-mathjax] PyYAML not installed — run `pip install pyyaml`",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MKDOCS_YML = REPO_ROOT / "site" / "mkdocs.yml"
+MATHJAX_CONFIG = REPO_ROOT / "site" / "docs" / "javascripts" / "mathjax-config.js"
+
+
+def fail(code: str, msg: str) -> None:
+    print(f"[preflight-mathjax] FAIL {code}: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def check_load_order() -> None:
+    if not MKDOCS_YML.exists():
+        fail("M0", f"{MKDOCS_YML} not found")
+
+    raw = MKDOCS_YML.read_text(encoding="utf-8")
+    # mkdocs.yml uses !!python/name:... for custom fences — strip those before
+    # safe_load, since we only care about extra_javascript here.
+    raw = re.sub(r"!!python/name:\S+", '""', raw)
+
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as e:
+        fail("M1", f"mkdocs.yml is not valid YAML: {e}")
+
+    entries = data.get("extra_javascript") if isinstance(data, dict) else None
+    if not entries:
+        fail("M1", "no extra_javascript entries in mkdocs.yml")
+
+    config_idx = next(
+        (i for i, e in enumerate(entries) if isinstance(e, str) and "mathjax-config" in e),
+        None,
+    )
+    cdn_idx = next(
+        (
+            i
+            for i, e in enumerate(entries)
+            if isinstance(e, str) and e.startswith("http") and "mathjax" in e.lower()
+        ),
+        None,
+    )
+
+    if config_idx is None:
+        fail("M2", "mathjax-config.js not listed in extra_javascript")
+    if cdn_idx is None:
+        fail("M3", "MathJax CDN URL not listed in extra_javascript")
+    if config_idx > cdn_idx:
+        fail(
+            "M4",
+            f"mathjax-config.js (position {config_idx}) must load BEFORE the MathJax CDN "
+            f"(position {cdn_idx}); window.MathJax is ignored otherwise",
+        )
+
+
+def check_config_js() -> None:
+    if not MATHJAX_CONFIG.exists():
+        fail("C0", f"{MATHJAX_CONFIG} not found")
+
+    text = MATHJAX_CONFIG.read_text(encoding="utf-8")
+    stripped = re.sub(r"//.*", "", text)
+    stripped = re.sub(r"/\*[\s\S]*?\*/", "", stripped)
+
+    for key in ("inlineMath", "displayMath"):
+        m = re.search(rf"\b{key}\s*:\s*(\[[^\]]*\])", stripped)
+        if not m:
+            fail("C1", f"mathjax-config.js missing tex.{key} delimiter list")
+        arr = m.group(1)
+        if re.search(r"""["']\$+["']""", arr):
+            fail(
+                "C2",
+                f"tex.{key} contains a bare $-delimiter — conflicts with "
+                f"arithmatex(generic: true); use only \\\\(...\\\\) / \\\\[...\\\\]",
+            )
+
+    if "document$.subscribe" not in stripped:
+        fail(
+            "C3",
+            "mathjax-config.js missing document$.subscribe; MathJax will not re-typeset "
+            "after Material instant-navigation page swaps",
+        )
+    if not re.search(r"typeof\s+document\$\s*===\s*['\"]undefined['\"]", stripped):
+        fail(
+            "C4",
+            "document$.subscribe is not guarded (no `typeof document$ === \"undefined\"` "
+            "check) — document$ is not defined at script-parse time; add a guard and "
+            "setTimeout retry",
+        )
+
+    for fn, code in (("typesetClear", "C5"), ("clearCache", "C6")):
+        if fn not in stripped:
+            fail(
+                code,
+                f"mathjax-config.js does not call MathJax.{fn} on navigation; "
+                f"subsequent pages render stale after SPA page swaps",
+            )
+
+
+def main() -> int:
+    check_load_order()
+    check_config_js()
+    print("[preflight-mathjax] OK — all static checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- New `scripts/preflight_mathjax.py`: static validator for the 4 failure modes logged in the issue (load order, delimiter conflict, SPA-nav guard, cache clears).
- `wiki-deploy` skill now runs the preflight before `mkdocs build`; non-zero exit blocks deploy.
- Troubleshooting section updated to point at the script.

Closes #1

## Scope note
Playwright/headless-browser assertion is marked *optional* in the issue and is intentionally deferred. The static check alone catches all three root causes from 2026-04-16 / -17 / -18; adding a browser runtime dependency to the deploy path isn't justified until static checks prove insufficient. Open a follow-up issue if a regression slips past.

## Test plan
- [x] Script passes on the current known-good tree (exit 0)
- [x] Script fails (exit 1) for each of the 4 modes — verified by mutation-then-restore harness:
  - M4: mathjax-config.js loaded after CDN → `FAIL M4`
  - C2: bare `$` delimiter in inlineMath → `FAIL C2`
  - C3: `document$.subscribe` removed → `FAIL C3`
  - C5: `typesetClear` removed → `FAIL C5`
- [ ] Next real deploy: confirm preflight runs cleanly before `mkdocs build` in the skill flow
- [ ] Intentionally break `mathjax-config.js` in a throwaway branch; confirm preflight blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)